### PR TITLE
Fix case issue with fidOrg, so that accType: 'CREDITCARD' will now work ...

### DIFF
--- a/lib/banking.js
+++ b/lib/banking.js
@@ -31,7 +31,7 @@ function Banking(args){
   if (!(this instanceof Banking)) return new Banking(args);
   this.opts = {
     fid: args.fid,
-    fidorg: args.fidOrg || '',
+    fidOrg: args.fidOrg || '',
     url: args.url,
     bankId: args.bankId || '', /* If bank account use your bank routing number otherwise set to null */
     user: args.user,

--- a/lib/ofx.js
+++ b/lib/ofx.js
@@ -33,7 +33,7 @@ OFX.createRequest = function(opts) {
       '<USERPASS>' + opts.password +
       '<LANGUAGE>ENG' +
       '<FI>' +
-      '<ORG>' + opts.fidorg +
+      '<ORG>' + opts.fidOrg +
       '<FID>' + opts.fid +
       '</FI>' +
       '<APPID>' + opts.app +

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "banking",
   "description": "The missing Bank API for getting you statement data",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Christian Sullivan <cs@euforic.co>",
   "keywords": [
     "banking",


### PR DESCRIPTION
This has a fix that makes the casing of fidorg consistent, and now allows accType: 'CREDITCARD' to pass a proper value.  Before, those requests would send a blank fidOrg entry.
