### PR TITLE
package.json: upgraded xml2json dependency to version 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "private": false,
   "homepage": "http://euforic.github.com/banking.js",
   "dependencies": {
-    "xml2json": "^0.4.0",
+    "xml2json": "^0.6.1",
     "debug": "^0.8.0",
     "superagent": "^0.17.0"
   },


### PR DESCRIPTION
Version 0.4.0 does not compile (because of an older node-expat) on my machine (OSX 10.10). Upgrading to 0.6.1 fixed the problem. All tests still pass.