### PR TITLE
Add delimiter param for header extensibility. fixes #8

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,6 +58,7 @@ var bank = Banking({
   , password: 'password'
   , accId: 0123456789 /* Account Number */
   , accType: 'CHECKING' /* CHECKING || SAVINGS || MONEYMRKT || CREDITCARD */
+  , delimiiter: '\n' , /* default \n, some use \r\n */
   , ofxVer: 103 /* default 102 */
   , app: 'QBKS' /* default  'QWIN' */
   , appVer: '1900' /* default 1700 */

--- a/Readme.md
+++ b/Readme.md
@@ -58,7 +58,7 @@ var bank = Banking({
   , password: 'password'
   , accId: 0123456789 /* Account Number */
   , accType: 'CHECKING' /* CHECKING || SAVINGS || MONEYMRKT || CREDITCARD */
-  , delimiiter: '\n' , /* default \n, some use \r\n */
+  , delimiter: '\n' , /* default \n, some use \r\n */
   , ofxVer: 103 /* default 102 */
   , app: 'QBKS' /* default  'QWIN' */
   , appVer: '1900' /* default 1700 */

--- a/lib/banking.js
+++ b/lib/banking.js
@@ -40,6 +40,7 @@ function Banking(args){
     brokerId: args.brokerId, /* For investment accounts */
     accType: args.accType,
     appVer: args.appVer || '1700',
+    delimiter: args.delimiter || '\n',
     ofxVer: args.ofxVer || '102',
     app: args.app || 'QWIN'
   };

--- a/lib/ofx.js
+++ b/lib/ofx.js
@@ -30,16 +30,18 @@ function getSignOnMsg(opts) {
 }
 
 function getOfxHeaders(opts) {
-  return 'OFXHEADER:100\n' +
-         'DATA:OFXSGML\n' +
-         'VERSION:'+opts.ofxVer+'\n' +
-         'SECURITY:NONE\n' +
-         'ENCODING:USASCII\n' +
-         'CHARSET:1252\n' +
-         'COMPRESSION:NONE\n' +
-         'OLDFILEUID:NONE\n' +
-         'NEWFILEUID:' + util.uuid(32) + '\n' +
-         '\n';
+  opts.delimiter = opts.delimiter || '\n'
+
+  return 'OFXHEADER:100' + opts.delimiter +
+         'DATA:OFXSGML' + opts.delimiter +
+         'VERSION:' + opts.ofxVer + opts.delimiter +
+         'SECURITY:NONE' + opts.delimiter +
+         'ENCODING:USASCII' + opts.delimiter +
+         'CHARSET:1252' + opts.delimiter +
+         'COMPRESSION:NONE' + opts.delimiter +
+         'OLDFILEUID:NONE' + opts.delimiter +
+         'NEWFILEUID:' + util.uuid(32) + opts.delimiter +
+         opts.delimiter;
 }
 
 


### PR DESCRIPTION
This allows users to give a 'delimiter' property, useful if the bank decides to be a special flower and accept \r\n instead of just \n.