### PR TITLE
error on headerString[key].split(2,/:/)

### DIFF
--- a/lib/ofx.js
+++ b/lib/ofx.js
@@ -161,7 +161,9 @@ OFX.parse = function (ofxStr, fn) {
   data.header = {};
 
   for(var key in headerString){
-    var headAttributes = headerString[key].split(/:/,2);
+    if (typeof headerString[key] != "function"){
+      var headAttributes = headerString[key].split(/:/,2);
+    }
     if (headAttributes[0]) data.header[headAttributes[0]] = headAttributes[1];
   }
   fn(data);

--- a/lib/ofx.js
+++ b/lib/ofx.js
@@ -161,7 +161,7 @@ OFX.parse = function (ofxStr, fn) {
   data.header = {};
 
   for(var key in headerString){
-    if (typeof headerString[key] != "function"){
+    if (typeof headerString[key] === "string"){
       var headAttributes = headerString[key].split(/:/,2);
     }
     if (headAttributes[0]) data.header[headAttributes[0]] = headAttributes[1];


### PR DESCRIPTION
the last argument of array is a function, you can not do split on function
i have added if(typeof headerString[key] != 'function') to fix it