### PR TITLE
Handle case when error happens on the client side (like DNS error)

### DIFF
--- a/lib/banking.js
+++ b/lib/banking.js
@@ -106,10 +106,15 @@ Banking.prototype.getStatement = function(args, fn) {
 
   req
     .end(function (err, res){
-      debug('Raw-Response:', res.text);
-      if (!res.ok || res.error) return fn(true, res.text);
-      ofx.parse(res.text, function(ofxObj){
-        fn(false, ofxObj);
-      });
+      if (err) {
+        debug('Request error', err);
+        fn(true, err);
+      } else if (res) {
+        debug('Raw-Response:', res.text);
+        if (!res.ok || res.error) return fn(true, res.text);
+        ofx.parse(res.text, function(ofxObj){
+          fn(false, ofxObj);
+        });
+      }
     });
 };


### PR DESCRIPTION
When the client can't resolve bank host name or can't connect to the IP or something happens to the SSL connection establishment, the `res` is undefined, and this causes a runtime exception. The proposed change handles this case and attempts to pass a meaningful error to the callback.
