### PR TITLE
Rearrange xml2js require and parser constructor to avoid webpack warning

### DIFF
--- a/lib/ofx.js
+++ b/lib/ofx.js
@@ -4,7 +4,8 @@
  * @type {[type]}
  */
 
-var parser = new require('xml2js').Parser({explicitArray: false})
+var xml2js = require('xml2js')
+  , parser = new xml2js.Parser({explicitArray: false})
   , util = require('./utils')
   , debug = require('debug')('banking:ofx');
 


### PR DESCRIPTION
Fixes #48 by separating the `require('xml2js')` call from the parser construction.

Tests passing:

``` text
> make test


  Banking
    banking.getStatement
      ✓ should return valid xml from bank server (428ms)
    .version
      ✓ should output the current version
    .parseFile
      ✓ should read the provided file and return JSON
      ✓ should read a OFX file with end-tags in elements and return JSON
    .parse
      ✓ should read the provided string and return JSON


  5 passing (461ms)
```