### PR TITLE
Add client uid field

### DIFF
--- a/lib/banking.js
+++ b/lib/banking.js
@@ -39,6 +39,7 @@ function Banking(args){
     accId: args.accId,  /* Account Number */
     brokerId: args.brokerId, /* For investment accounts */
     accType: args.accType,
+    clientId: args.clientId,
     appVer: args.appVer || '1700',
     ofxVer: args.ofxVer || '102',
     app: args.app || 'QWIN'

--- a/lib/ofx.js
+++ b/lib/ofx.js
@@ -26,6 +26,7 @@ function getSignOnMsg(opts) {
         '</FI>' +
         '<APPID>' + opts.app +
         '<APPVER>' + opts.appVer +
+        (typeof opts.clientId !== 'undefined' ? '<CLIENTUID>' + opts.clientId : '') +
         '</SONRQ>' +
         '</SIGNONMSGSRQV1>';
 }


### PR DESCRIPTION
Per the discussion [here](http://www.ofxhome.com/ofxforum/viewtopic.php?id=47456). TL;DR: Chase requires each client to submit a unique identifier, which it apparently then uses to authorize devices. So we need to be able to pass in that field or they throw a hissy fit.