### PR TITLE
Add discovercard support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -61,6 +61,11 @@ var bank = Banking({
   , ofxVer: 103 /* default 102 */
   , app: 'QBKS' /* default  'QWIN' */
   , appVer: '1900' /* default 1700 */
+  
+  // headers are only required if your ofx server is very picky, defaults below
+  // add only the headers you want sent
+  // the order in this array is also the order they are sent
+  , headers: ['Host', 'Accept', 'User-Agent', 'Content-Type', 'Content-Length', 'Connection']
 });
 ```
 

--- a/lib/banking.js
+++ b/lib/banking.js
@@ -8,8 +8,7 @@
  * @type {[type]}
  */
 
-var request = require('superagent')
-  , fs = require('fs')
+var fs = require('fs')
   , ofx = require('./ofx')
   , pkg = require('../package')
   , util = require('./utils')

--- a/lib/banking.js
+++ b/lib/banking.js
@@ -42,7 +42,12 @@ function Banking(args){
     clientId: args.clientId,
     appVer: args.appVer || '1700',
     ofxVer: args.ofxVer || '102',
-    app: args.app || 'QWIN'
+    app: args.app || 'QWIN',
+    'User-Agent': args['User-Agent'] || 'banking-js',
+    'Content-Type': args['Content-Type'] || 'application/x-ofx' ,
+    Accept: args.Accept || 'application/ofx',
+    Connection: args.Connection || 'Close',
+    headers: args.headers || ['Host', 'Accept', 'User-Agent', 'Content-Type', 'Content-Length', 'Connection']
   };
 }
 
@@ -82,36 +87,19 @@ Banking.parse = function(str, fn){
 };
 
 /**
- * Fetches Ofx String from Bank Server and parse to json or returns valid XML
- *
- * @param {JSON} o Request Config Settings
- * @param {String} format (Options are 'xml' || 'json' if omitted defaults to 'json')
- * @param {Function} cb
- * @return {XML|JSON}
- * @api public
+ * Get a list of transactions from the ofx server
+ * @param args set start and end date for transaction range
+ * @param fn callback(error, transactions)
  */
-
 Banking.prototype.getStatement = function(args, fn) {
   var opts = util.mixin(this.opts, args);
   var ofxReq = ofx.createRequest(opts);
 
-  var req = request
-    .post(this.opts.url)
-    .type('application/x-ofx')
-    .set({'User-Agent' : 'banking-js'})
-    .set({'Accept' : 'application/ofx'})
-    .send(ofxReq)
-    .buffer()
-
-  if (!fn) return req;
-
-  req
-    .end(function (err, res){
-      debug('Raw-Response:', res.text);
-      if (err) return fn(true, err);
-      if (!res.ok || res.error) return fn(true, res.text);
-      ofx.parse(res.text, function(ofxObj){
-        fn(false, ofxObj);
-      });
+  util.request(this.opts, ofxReq, function(err, response) {
+    debug('Raw-Response:', response);
+    if (err) return fn(err, err);
+    ofx.parse(response, function(ofxObj) {
+      fn(false, ofxObj);
     });
+  });
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
-
+var tls = require('tls');
+var url = require('url');
 
 /**
  * Unique Id Generator
@@ -46,4 +47,52 @@ Util.mixin = function (base, obj) {
     obj[key] = (obj[key]) ? obj[key] : base[key];
   }
   return obj;
-}
+};
+
+/**
+ * Makes a secure request to an ofx server and posts an OFX payload
+ * @param options
+ * @param ofxPayload
+ * @param cb
+ */
+Util.request = function(options, ofxPayload, cb) {
+  var parsedUrl = url.parse(options.url);
+  var tlsOpts = {
+    port: parsedUrl.port || (parsedUrl.protocol === 'https:' ? 443 : 80),
+    host: parsedUrl.hostname
+  };
+  var socket = tls.connect(tlsOpts, function() {
+    var buffer = 'POST ' + parsedUrl.path + ' HTTP/1.1\r\n';
+    options.headers.forEach(function(header) {
+      var value;
+      if (options[header]) {
+        value = options[header];
+      } else if (header === 'Content-Length') {
+        value = ofxPayload.length;
+      } else if (header === 'Host') {
+        value = parsedUrl.host;
+      }
+      buffer += header + ': ' + value + '\r\n';
+    });
+    buffer += '\r\n';
+    buffer += ofxPayload;
+    socket.write(buffer);
+  });
+  var data = '';
+  socket.on('data', function(chunk) {
+    data += chunk;
+  });
+  socket.on('end', () => {
+    var error = true;
+    var httpHeaderMatcher = new RegExp(/HTTP\/\d\.\d (\d{3}) (.*)/);
+    var matches = httpHeaderMatcher.exec(data);
+    if (matches && matches.length > 2) {
+      if (parseInt(matches[1], 10) === 200) {
+        error = false;
+      } else {
+        error = new Error(matches[0]);
+      }
+    }
+    cb(error, data);
+  });
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,7 +82,7 @@ Util.request = function(options, ofxPayload, cb) {
   socket.on('data', function(chunk) {
     data += chunk;
   });
-  socket.on('end', () => {
+  socket.on('end', function() {
     var error = true;
     var httpHeaderMatcher = new RegExp(/HTTP\/\d\.\d (\d{3}) (.*)/);
     var matches = httpHeaderMatcher.exec(data);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "homepage": "http://euforic.github.com/banking.js",
   "dependencies": {
     "debug": "^2.3.3",
-    "superagent": "^3.1.0",
     "xml2js": "^0.4.17"
   },
   "devDependencies": {

--- a/test/parsing.js
+++ b/test/parsing.js
@@ -5,7 +5,7 @@ var Banking = require('..')
 describe('Banking', function(){
 
   describe('banking.getStatement', function() {
-    it('should return valid xml from bank server', function(done){
+    it('should return valid xml from the wells fargo server', function(done){
 
       var banking = Banking({
         fid: 3001,
@@ -18,6 +18,28 @@ describe('Banking', function(){
         url: 'https://www.oasis.cfree.com/3001.ofxgp'
       });
 
+      //If second param is omitted JSON will be returned by default
+      banking.getStatement({start:20131101, end:20131120}, function (err, res) {
+        if(err) done(res)
+        res.body.should.be.an.instanceof(Object);
+        res.body.should.have.property('OFX');
+        done();
+      });
+    });
+
+    it('should return valid xml from the discovercard server', function(done){
+
+      var banking = Banking({
+        fid: 7101,
+        fidOrg: 'Discover Financial Services',
+        accType: 'checking',
+        accId: '234343434',
+        bankId: '342342',
+        user: 'username',
+        url: 'https://ofx.discovercard.com',
+        password: 'password',
+        headers: ['Content-Type', 'Host', 'Content-Length', 'Connection']
+      });
 
       //If second param is omitted JSON will be returned by default
       banking.getStatement({start:20131101, end:20131120}, function (err, res) {


### PR DESCRIPTION
Fixes #50 

Added support by replacing superagent with a custom request function which allows changing what headers are sent, and in what order.

Also added a second unit test to check discovercard connectivity directly